### PR TITLE
Removing browser default margin in body

### DIFF
--- a/style.css
+++ b/style.css
@@ -2,6 +2,7 @@ body {
 	background-color: #113B92;
 	font-family: 'Open Sans', sans-serif;
 	color: #FFFFFF;
+	margin: 0;
 }
 
 nav {


### PR DESCRIPTION
Now text doesn't go below the page
